### PR TITLE
Refine monospace font selection for preview

### DIFF
--- a/src/components/TextPreview.tsx
+++ b/src/components/TextPreview.tsx
@@ -6,11 +6,9 @@ interface TextPreviewProps {
 }
 
 const FONTS = {
-  'noto-jp': "'Noto Sans Mono CJK JP', monospace",
-  'source-jp': "'Source Han Mono', monospace",
+  'noto-jp': "'Noto Sans Mono', monospace",
   'mplus': "'M PLUS 1 Code', monospace",
   'ibm-jp': "'IBM Plex Mono', monospace",
-  'roboto-jp': "'Roboto Mono', monospace"
 } as const;
 
 const TextPreview: React.FC<TextPreviewProps> = ({ text }) => {
@@ -48,11 +46,9 @@ const TextPreview: React.FC<TextPreviewProps> = ({ text }) => {
                       rounded px-2 py-1 text-gray-700 dark:text-gray-300 focus:outline-none 
                       focus:ring-1 focus:ring-indigo-500"
           >
-            <option value="noto-jp">Noto Sans Mono CJK JP</option>
-            <option value="source-jp">Source Han Mono</option>
+            <option value="noto-jp">Noto Sans Mono</option>
             <option value="mplus">M PLUS 1 Code</option>
             <option value="ibm-jp">IBM Plex Mono</option>
-            <option value="roboto-jp">Roboto Mono</option>
           </select>
           <select
             value={language}

--- a/src/index.css
+++ b/src/index.css
@@ -10,8 +10,8 @@
   }
   
   /* Import Japanese monospace fonts */
-  @import url('https://fonts.googleapis.com/css2?family=M+PLUS+1+Code:wght@400;500&family=Roboto+Mono:wght@400;500&family=IBM+Plex+Mono:wght@400;500&display=swap');
-  @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500&display=swap');
+  @import url('https://fonts.googleapis.com/css2?family=M+PLUS+1+Code:wght@400;500&family=IBM+Plex+Mono:wght@400;500&display=swap');
+  @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+Mono:wght@400;500&display=swap');
   
   /* Custom scrollbar for code blocks */
   pre::-webkit-scrollbar {


### PR DESCRIPTION
This commit updates the available monospace fonts for the text preview functionality, ensuring better support for Japanese and English characters.

Key changes:
- Corrected 'Noto Sans Mono CJK JP' to 'Noto Sans Mono' and updated its import.
- Replaced 'Source Han Mono' (unavailable on Google Fonts) with 'Source Code Pro', then subsequently removed 'Source Code Pro' as it lacks adequate Japanese character support.
- Removed 'Roboto Mono' due to inadequate Japanese character support.
- The final list of available monospace fonts includes:
    - Noto Sans Mono
    - M PLUS 1 Code
    - IBM Plex Mono
- Updated Google Fonts imports in `index.css` to match the selected fonts.
- Removed unused font options from the dropdown in `TextPreview.tsx`.

These changes provide a curated list of three reliable monospace fonts for previewing mixed Japanese and English text.